### PR TITLE
Browser styles auto-prefix.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby "2.3.0"
 
+gem "autoprefixer-rails"
 gem "bourbon"
 gem "breakpoint"
 gem "coveralls", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    autoprefixer-rails (6.3.6)
+      execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -241,6 +243,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   bourbon
   breakpoint
   capybara

--- a/app/assets/stylesheets/browserlist
+++ b/app/assets/stylesheets/browserlist
@@ -1,0 +1,1 @@
+last 2 versions


### PR DESCRIPTION
#### What does this PR do?

Enables browser style auto-prefixing.

#### Description of Task to be completed?

Installed the `autoprefixer-rails` gem to handle auto-prefixing CSS styles.
Example when I write:
```css
.some-class {
    display: flex;
}
```
The gem will add the various browser specific vendor prefixes ike this;
```css
.some-class {
    display: -webkit-box;
    display: -webkit-flex;
    display: -ms-flexbox;
    display: flex;
}
```

#### How should this be manually tested?

View the compiled version of CSS styles, there will be several instances of vendor prefixed markup.

#### What are the relevant pivotal tracker stories?

#117284527