### PR TITLE
Remove redundant ":each" from before block.

### DIFF
--- a/spec/controllers/bookings_controller_spec.rb
+++ b/spec/controllers/bookings_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe BookingsController, type: :controller do
 
   describe "Update booking" do
     context "When booking attributes are valid" do
-      before :each do
+      before do
         booking.save
         allow(booking).to receive(:update).
           with(valid_attributes.stringify_keys) { true }
@@ -134,7 +134,7 @@ RSpec.describe BookingsController, type: :controller do
     end
 
     context "When booking attributes are invalid" do
-      before :each do
+      before do
         booking.save
         allow(booking).to receive(:update).
           with(invalid_attributes.stringify_keys) { false }
@@ -149,7 +149,7 @@ RSpec.describe BookingsController, type: :controller do
 
   describe "Create booking" do
     context "When booking attributes are valid" do
-      before :each do
+      before do
         post :create, booking: booking.attributes
       end
 
@@ -165,7 +165,7 @@ RSpec.describe BookingsController, type: :controller do
     end
 
     context "When booking attributes are invalid" do
-      before :each do
+      before do
         post :create, booking: invalid_attributes
       end
 
@@ -181,7 +181,7 @@ RSpec.describe BookingsController, type: :controller do
 
   describe "Delete booking" do
     context "When a booking is deleted" do
-      before :each do
+      before do
         booking.save
         delete :destroy, id: booking
       end
@@ -198,7 +198,7 @@ RSpec.describe BookingsController, type: :controller do
 
   describe "Manage bookings" do
     context "When a booking is retrieved" do
-      before :each do
+      before do
         allow(controller).to receive(:current_user) { user }
         booking.save
       end

--- a/spec/controllers/flights_controller_spec.rb
+++ b/spec/controllers/flights_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FlightsController, type: :controller do
 
   describe "Searching flights" do
     context "When I search for a flight" do
-      before :each do
+      before do
         2.times { create(:airport) }
         flight
       end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SessionsController, type: :controller do
 
   describe "Sessions pages" do
     context "When I visit the login page" do
-      before :each do
+      before do
         get :new
       end
 
@@ -15,7 +15,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context "When I logout a user" do
-      before :each do
+      before do
         delete :destroy
       end
 
@@ -26,7 +26,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context "When a user successfully logs in" do
-      before :each do
+      before do
         post :create,
              session: {
                email_username: user.email,
@@ -50,7 +50,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context "When a user fails to log in" do
-      before :each do
+      before do
         post :create,
              session: {
                email_username: Faker::Internet.email,
@@ -68,7 +68,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context "When a user tries to login using their email" do
-      before :each do
+      before do
         post :check_username_email,
              session: { email_username: user.email },
              format: :json
@@ -80,7 +80,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context "When a user tries to login using their username" do
-      before :each do
+      before do
         post :check_username_email,
              session: { email_username: user.username },
              format: :json


### PR DESCRIPTION
#### What does this PR do?

Refactor tests to remove redundant `:each` from `before` blocks in the specs.

[#120905585]